### PR TITLE
feat(architecture): implement battlefield scene with chat interaction

### DIFF
--- a/public/architecture/test-case-002/battlefield-ts002-0001.json
+++ b/public/architecture/test-case-002/battlefield-ts002-0001.json
@@ -1,0 +1,10 @@
+{
+    "description": "This is the battlefield 0001 scene.",
+    "onRenderCompleted": [
+        {
+            "command": "STACK_SCENE",
+            "scene": "chat",
+            "sceneResource": "chat-ts002-battle-0001.json"
+        }
+    ]
+}

--- a/public/architecture/test-case-002/chat-ts002-0001.json
+++ b/public/architecture/test-case-002/chat-ts002-0001.json
@@ -1,0 +1,14 @@
+{
+    "events": [
+        {
+            "eventCommand": "SHOW_MESSAGE",
+            "characterName": "Narrator",
+            "message": "This is the test case 002, after this chat, the player will be sent to the battlefield."
+        }
+    ],
+    "finishEvent": {
+        "eventCommand": "INVOKE_SCENE",
+        "scene": "battlefield",
+        "sceneResource": "battlefield-ts002-0001.json"
+    }
+}

--- a/public/architecture/test-case-002/chat-ts002-battle-0001.json
+++ b/public/architecture/test-case-002/chat-ts002-battle-0001.json
@@ -1,0 +1,23 @@
+{
+    "events": [
+        {
+            "eventCommand": "WRITE_CONSOLE",
+            "type": "info",
+            "message": "Chat in battlefield scene loaded."
+        },
+        {
+            "eventCommand": "SHOW_MESSAGE",
+            "characterName": "Narrator",
+            "message": "This is the test message that invoked in Battlefield scene."
+        },
+        {
+            "eventCommand": "WRITE_CONSOLE",
+            "type": "info",
+            "message": "Chat in battlefield scene finished."
+        }
+    ],
+    "finishEvent": {
+        "eventCommand": "HIDE_SCENE",
+        "scene": "chat"
+    }
+}

--- a/public/architecture/test-case-002/init.json
+++ b/public/architecture/test-case-002/init.json
@@ -11,5 +11,10 @@
   },
   {
     "command": "RESET_STATE"
+  },
+  {
+    "command": "INVOKE_SCENE",
+    "scene": "chat",
+    "sceneResource": "chat-ts002-0001.json"
   }
 ]

--- a/src/components/Architecture/TheaterCore.tsx
+++ b/src/components/Architecture/TheaterCore.tsx
@@ -56,6 +56,21 @@ const TheaterCore: React.FC<TheaterCoreProps> = ({ width = '100%', height = '100
         setScenes(newScenes);
         setSceneResource(command.sceneResource);
         break;
+      case 'STACK_SCENE':
+        // Keep existing scenes visible and add the new scene
+        setScenes(prev => ({
+          ...prev,
+          [command.scene]: true
+        }));
+        setSceneResource(command.sceneResource);
+        break;
+      case 'HIDE_SCENE':
+        // Hide the specified scene while preserving others
+        setScenes(prev => ({
+          ...prev,
+          [command.scene]: false
+        }));
+        break;
       case 'INVOKE_SCRIPT':
         await SceneCommandUtils.executeScript(command.script, command.entryPoint);
         break;

--- a/src/components/Architecture/commands/SceneCommand.ts
+++ b/src/components/Architecture/commands/SceneCommand.ts
@@ -1,6 +1,6 @@
 import {Scene} from "./Scene.ts";
 
-export type SceneCommand = INVOKE_SCENE | INVOKE_SCRIPT | RESET_STATE;
+export type SceneCommand = INVOKE_SCENE | INVOKE_SCRIPT | STACK_SCENE | RESET_STATE | HIDE_SCENE;
 
 type INVOKE_SCENE = {
   command: 'INVOKE_SCENE';
@@ -14,8 +14,19 @@ type INVOKE_SCRIPT = {
   entryPoint: string;
 }
 
+type STACK_SCENE = {
+  command: 'STACK_SCENE';
+  scene: Scene;
+  sceneResource: string;
+}
+
 type RESET_STATE = {
   command: 'RESET_STATE';
+}
+
+type HIDE_SCENE = {
+  command: 'HIDE_SCENE';
+  scene: Scene;
 }
 
 

--- a/src/components/Architecture/commands/TheaterCommand.ts
+++ b/src/components/Architecture/commands/TheaterCommand.ts
@@ -1,5 +1,5 @@
-import {Scene} from "./Scene.ts";
-import {SceneCommand} from "./SceneCommand.ts";
+import {Scene} from "./Scene";
+import {SceneCommand} from "./SceneCommand";
 
 export type TheaterCommand =
   | { type: 'CHANGE_SCENE'; payload: Record<Scene, boolean> }

--- a/src/components/Architecture/scenes/Battlefield.tsx
+++ b/src/components/Architecture/scenes/Battlefield.tsx
@@ -1,6 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useTheater } from '../TheaterCore';
+import BattlefieldCore from './battlefield/BattlefieldCore';
 
 const Battlefield: React.FC = () => {
+  const { sceneResource, dispatchSceneCommand } = useTheater();
+
+  useEffect(() => {
+    if (sceneResource) {
+      // Load and execute the scene resource
+      fetch(`/architecture/${localStorage.getItem('selectedTestCase') || 'test-case-001'}/${sceneResource}`)
+        .then(response => response.json())
+        .then(data => {
+          if (data.onRenderCompleted) {
+            data.onRenderCompleted.forEach((command: any) => {
+              dispatchSceneCommand(command);
+            });
+          }
+        })
+        .catch(error => {
+          console.error('Error loading battlefield scene resource:', error);
+        });
+    }
+  }, [sceneResource, dispatchSceneCommand]);
+
   return (
     <div style={{ 
       width: '100%', 
@@ -12,13 +34,7 @@ const Battlefield: React.FC = () => {
       alignItems: 'center',
       backgroundColor: 'rgba(156, 39, 176, 0.1)'
     }}>
-      <div style={{ 
-        padding: '10px 20px',
-        backgroundColor: 'rgba(255, 255, 255, 0.8)',
-        borderRadius: '4px'
-      }}>
-        Battlefield
-      </div>
+      <BattlefieldCore />
     </div>
   );
 };

--- a/src/components/Architecture/scenes/battlefield/BattlefieldCore.tsx
+++ b/src/components/Architecture/scenes/battlefield/BattlefieldCore.tsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react';
+import { useTheater } from '../../TheaterCore';
+
+const BattlefieldCore: React.FC = () => {
+  const { sceneResource, dispatchSceneCommand } = useTheater();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sceneResource) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchBattlefieldData = async () => {
+      try {
+        setLoading(true);
+        const selectedTestCase = localStorage.getItem('selectedTestCase') || 'test-case-001';
+        const response = await fetch(`/architecture/${selectedTestCase}/${sceneResource}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch battlefield data: ${response.status}`);
+        }
+        const data = await response.json();
+        
+        // Only execute onRenderCompleted if it's from the battlefield scene
+        if (data.onRenderCompleted && sceneResource.includes('battlefield')) {
+          data.onRenderCompleted.forEach((command: any) => {
+            dispatchSceneCommand(command);
+          });
+        }
+        
+        setLoading(false);
+      } catch (err) {
+        console.error('Error fetching battlefield data:', err);
+        setError(err instanceof Error ? err.message : 'Unknown error');
+        setLoading(false);
+      }
+    };
+
+    fetchBattlefieldData();
+  }, [sceneResource, dispatchSceneCommand]);
+
+  if (loading) {
+    return <div>Loading battlefield data...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <div style={{ 
+      padding: '10px 20px',
+      backgroundColor: 'rgba(255, 255, 255, 0.8)',
+      borderRadius: '4px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '10px'
+    }}>
+      <div>Battlefield</div>
+      <div style={{ fontSize: '0.8em', color: '#666' }}>
+        This is the battlefield scene. It can stack other scenes on top.
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(BattlefieldCore);

--- a/src/components/Architecture/scenes/chat/ChatCore.tsx
+++ b/src/components/Architecture/scenes/chat/ChatCore.tsx
@@ -19,7 +19,7 @@ interface WriteConsoleEvent {
 type ChatEvent = ShowMessageEvent | WriteConsoleEvent;
 
 interface FinishEvent {
-  eventCommand: 'INVOKE_SCENE';
+  eventCommand: 'INVOKE_SCENE' | 'HIDE_SCENE';
   scene: string;
   sceneResource: string;
 }
@@ -58,11 +58,18 @@ const ChatCore: React.FC = () => {
       setCurrentEventIndex(prev => prev + 1);
     } else {
       // All messages shown, trigger finish event
-      dispatchSceneCommand({
-        command: 'INVOKE_SCENE',
-        scene: chatData.finishEvent.scene as any,
-        sceneResource: chatData.finishEvent.sceneResource
-      });
+      if (chatData.finishEvent.eventCommand === 'HIDE_SCENE') {
+        dispatchSceneCommand({
+          command: 'HIDE_SCENE',
+          scene: 'chat'
+        });
+      } else {
+        dispatchSceneCommand({
+          command: chatData.finishEvent.eventCommand,
+          scene: chatData.finishEvent.scene as any,
+          sceneResource: chatData.finishEvent.sceneResource
+        });
+      }
     }
   }, [chatData, currentEventIndex, dispatchSceneCommand]);
 


### PR DESCRIPTION
Test Case 002 demonstrates a complete scene transition flow with battlefield and chat interaction:

Initialization Flow:
1. System initialization (init.json)
   - Executes init.ts script
   - Executes reset.ts script
   - Resets game state
   - Invokes initial chat scene

2. Initial Chat Scene (chat-ts002-0001.json)
   - Displays introduction message
   - Transitions to battlefield scene via INVOKE_SCENE

3. Battlefield Scene (battlefield-ts002-0001.json)
   - Loads battlefield environment
   - Stacks chat scene on top via STACK_SCENE
   - Maintains battlefield as base scene

4. Battlefield Chat (chat-ts002-battle-0001.json)
   - Logs chat initialization
   - Displays battlefield-specific message
   - Logs chat completion
   - Self-destructs via HIDE_SCENE

Key Architectural Changes:
- Enhanced ChatCore to support HIDE_SCENE command
- Updated FinishEvent interface to handle both INVOKE_SCENE and HIDE_SCENE
- Implemented proper scene stacking and cleanup
- Fixed infinite loop in scene transition by ensuring chat properly cleans up

Scene Hierarchy:
- Base Scene: Battlefield (persistent)
- Stacked Scene: Chat (temporary, self-destructing)
- Proper z-index management for scene layering

This implementation demonstrates:
1. Proper scene initialization and cleanup
2. Scene stacking without memory leaks
3. Clean transition between scenes
4. Proper event logging and state management
5. Self-contained scene lifecycle management